### PR TITLE
Add Throttle versions of logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,4 +40,5 @@ install(
 install(TARGETS test_logging
     RUNTIME DESTINATION lib/${PROJECT_NAME})
 
+ament_export_include_directories(include)
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
 find_package(fmt REQUIRED)
 
 
@@ -28,7 +29,7 @@ target_include_directories(test_logging
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 
-ament_target_dependencies(test_logging rclcpp fmt)
+ament_target_dependencies(test_logging rclcpp rclcpp_lifecycle fmt)
 
 ament_export_dependencies(rclcpp fmt)
 

--- a/include/ros2_logging_fmt/ros2_logging_fmt.hpp
+++ b/include/ros2_logging_fmt/ros2_logging_fmt.hpp
@@ -25,9 +25,9 @@ public:
   }
 
   template<typename... Args>
-  void info_throttle(rclcpp::Clock::SharedPtr clock, int duration, const char* str,  Args... args)
+  void info_throttle(rclcpp::Clock& clock, int duration, const char* str,  Args... args)
   {
-      RCLCPP_INFO_THROTTLE(rclcpp_logger_, *clock, duration, write_buffer(str, args...) );
+      RCLCPP_INFO_THROTTLE(rclcpp_logger_, clock, duration, write_buffer(str, args...) );
   }
 
   template<typename... Args>
@@ -43,9 +43,9 @@ public:
   }
 
   template<typename... Args>
-  void warn_throttle(rclcpp::Clock::SharedPtr clock, int duration, const char* str,  Args... args)
+  void warn_throttle(rclcpp::Clock &clock, int duration, const char* str,  Args... args)
   {
-      RCLCPP_WARN_THROTTLE(rclcpp_logger_, *clock, duration, write_buffer(str, args...) );
+      RCLCPP_WARN_THROTTLE(rclcpp_logger_, clock, duration, write_buffer(str, args...) );
   }
 
   template<typename... Args>
@@ -61,9 +61,9 @@ public:
   }
 
   template<typename... Args>
-  void error_throttle(rclcpp::Clock::SharedPtr clock, int duration, const char* str,  Args... args)
+  void error_throttle(rclcpp::Clock& clock, int duration, const char* str,  Args... args)
   {
-      RCLCPP_ERROR_THROTTLE(rclcpp_logger_, *clock, duration, write_buffer(str, args...) );
+      RCLCPP_ERROR_THROTTLE(rclcpp_logger_, clock, duration, write_buffer(str, args...) );
   }
 
   template<typename... Args>
@@ -79,9 +79,9 @@ public:
   }
 
   template<typename... Args>
-  void fatal_throttle(rclcpp::Clock::SharedPtr clock, int duration, const char* str,  Args... args)
+  void fatal_throttle(rclcpp::Clock& clock, int duration, const char* str,  Args... args)
   {
-      RCLCPP_FATAL_THROTTLE(rclcpp_logger_, *clock, duration, write_buffer(str, args...) );
+      RCLCPP_FATAL_THROTTLE(rclcpp_logger_, clock, duration, write_buffer(str, args...) );
   }
 
   template<typename... Args>
@@ -97,9 +97,9 @@ public:
   }
 
   template<typename... Args>
-  void debug_throttle(rclcpp::Clock::SharedPtr clock, int duration, const char* str,  Args... args)
+  void debug_throttle(rclcpp::Clock& clock, int duration, const char* str,  Args... args)
   {
-      RCLCPP_DEBUG_THROTTLE(rclcpp_logger_, *clock, duration, write_buffer(str, args...) );
+      RCLCPP_DEBUG_THROTTLE(rclcpp_logger_, clock, duration, write_buffer(str, args...) );
   }
 
   template<typename... Args>

--- a/include/ros2_logging_fmt/ros2_logging_fmt.hpp
+++ b/include/ros2_logging_fmt/ros2_logging_fmt.hpp
@@ -15,10 +15,25 @@ public:
   Logger(rclcpp::Logger rclcpp_logger): rclcpp_logger_(rclcpp_logger)
   {}
 
+  Logger(rclcpp::Logger rclcpp_logger, rclcpp::Clock::SharedPtr clock): rclcpp_logger_(rclcpp_logger)
+  { clk = clock; }
+
   template<typename... Args>
   void info(const char* str, Args... args)
   {
     RCLCPP_INFO(rclcpp_logger_, write_buffer(str, args...) );
+  }
+
+  template<typename... Args>
+  void info_throttle(const char* str, rclcpp::Clock::SharedPtr clock, int duration, Args... args)
+  {
+      RCLCPP_INFO_THROTTLE(rclcpp_logger_, *clock, duration, write_buffer(str, args...) );
+  }
+
+  template<typename... Args>
+  void info_throttle(int duration, const char* str, Args... args)
+  {
+      RCLCPP_INFO_THROTTLE(rclcpp_logger_, *clk, duration, write_buffer(str, args...) );
   }
 
   template<typename... Args>
@@ -28,9 +43,33 @@ public:
   }
 
   template<typename... Args>
+  void warn_throttle(const char* str, rclcpp::Clock::SharedPtr clock, int duration, Args... args)
+  {
+      RCLCPP_WARN_THROTTLE(rclcpp_logger_, *clock, duration, write_buffer(str, args...) );
+  }
+
+  template<typename... Args>
+  void warn_throttle(int duration, const char* str, Args... args)
+  {
+      RCLCPP_WARN_THROTTLE(rclcpp_logger_, *clk, duration, write_buffer(str, args...) );
+  }
+
+  template<typename... Args>
   void error(const char* str, Args... args)
   {
     RCLCPP_ERROR(rclcpp_logger_, write_buffer(str, args...) );
+  }
+
+  template<typename... Args>
+  void error_throttle(const char* str, rclcpp::Clock::SharedPtr clock, int duration, Args... args)
+  {
+      RCLCPP_ERROR_THROTTLE(rclcpp_logger_, *clock, duration, write_buffer(str, args...) );
+  }
+
+  template<typename... Args>
+  void error_throttle(int duration, const char* str, Args... args)
+  {
+      RCLCPP_ERROR_THROTTLE(rclcpp_logger_, *clk, duration, write_buffer(str, args...) );
   }
 
   template<typename... Args>
@@ -40,24 +79,49 @@ public:
   }
 
   template<typename... Args>
+  void fatal_throttle(const char* str, rclcpp::Clock::SharedPtr clock, int duration, Args... args)
+  {
+      RCLCPP_FATAL_THROTTLE(rclcpp_logger_, *clock, duration, write_buffer(str, args...) );
+  }
+
+  template<typename... Args>
+  void fatal_throttle(int duration, const char* str, Args... args)
+  {
+      RCLCPP_FATAL_THROTTLE(rclcpp_logger_, *clk, duration, write_buffer(str, args...) );
+  }
+
+  template<typename... Args>
   void debug(const char* str, Args... args)
   {
     RCLCPP_DEBUG(rclcpp_logger_, write_buffer(str, args...) );
   }
 
+  template<typename... Args>
+  void debug_throttle(const char* str, rclcpp::Clock::SharedPtr clock, int duration, Args... args)
+  {
+      RCLCPP_DEBUG_THROTTLE(rclcpp_logger_, *clock, duration, write_buffer(str, args...) );
+  }
+
+  template<typename... Args>
+  void debug_throttle(int duration, const char* str, Args... args)
+  {
+      RCLCPP_DEBUG_THROTTLE(rclcpp_logger_, *clk, duration, write_buffer(str, args...) );
+  }
+
   rclcpp::Logger rclcpp_logger_;
 private:
 
+  rclcpp::Clock::SharedPtr clk;
   template<typename... Args>
   const char* write_buffer(const char* str, Args... args)
   {
-     // static buffer with 500 characters pre-allocated 
+     // static buffer with 500 characters pre-allocated
     static thread_local std::string buffer = [](){
-      std::string tmp; 
+      std::string tmp;
       tmp.reserve(500);
       return tmp;
     }();
-    
+
     buffer.clear();
     fmt::format_to(std::back_inserter(buffer), str, args...);
     return buffer.c_str();

--- a/include/ros2_logging_fmt/ros2_logging_fmt.hpp
+++ b/include/ros2_logging_fmt/ros2_logging_fmt.hpp
@@ -2,6 +2,7 @@
 #define ROS2_LOGGING_PLUS_HPP
 
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
 
 #define FMT_HEADER_ONLY
 #include "fmt/format.h"
@@ -15,8 +16,14 @@ public:
   Logger(rclcpp::Logger rclcpp_logger): rclcpp_logger_(rclcpp_logger)
   {}
 
-  Logger(rclcpp::Logger rclcpp_logger, rclcpp::Clock::SharedPtr clock): rclcpp_logger_(rclcpp_logger)
-  { clk = clock; }
+  Logger(rclcpp::Logger rclcpp_logger, rclcpp::Clock::SharedPtr clock): rclcpp_logger_(rclcpp_logger), clk(clock)
+  {}
+
+  Logger(rclcpp::Node& n): rclcpp_logger_(n.get_logger()), clk(n.get_clock())
+  {}
+
+  Logger(rclcpp_lifecycle::LifecycleNode& n): rclcpp_logger_(n.get_logger()), clk(n.get_clock())
+  {}
 
   template<typename... Args>
   void info(const char* str, Args... args)

--- a/include/ros2_logging_fmt/ros2_logging_fmt.hpp
+++ b/include/ros2_logging_fmt/ros2_logging_fmt.hpp
@@ -25,7 +25,7 @@ public:
   }
 
   template<typename... Args>
-  void info_throttle(const char* str, rclcpp::Clock::SharedPtr clock, int duration, Args... args)
+  void info_throttle(rclcpp::Clock::SharedPtr clock, int duration, const char* str,  Args... args)
   {
       RCLCPP_INFO_THROTTLE(rclcpp_logger_, *clock, duration, write_buffer(str, args...) );
   }
@@ -43,7 +43,7 @@ public:
   }
 
   template<typename... Args>
-  void warn_throttle(const char* str, rclcpp::Clock::SharedPtr clock, int duration, Args... args)
+  void warn_throttle(rclcpp::Clock::SharedPtr clock, int duration, const char* str,  Args... args)
   {
       RCLCPP_WARN_THROTTLE(rclcpp_logger_, *clock, duration, write_buffer(str, args...) );
   }
@@ -61,7 +61,7 @@ public:
   }
 
   template<typename... Args>
-  void error_throttle(const char* str, rclcpp::Clock::SharedPtr clock, int duration, Args... args)
+  void error_throttle(rclcpp::Clock::SharedPtr clock, int duration, const char* str,  Args... args)
   {
       RCLCPP_ERROR_THROTTLE(rclcpp_logger_, *clock, duration, write_buffer(str, args...) );
   }
@@ -79,7 +79,7 @@ public:
   }
 
   template<typename... Args>
-  void fatal_throttle(const char* str, rclcpp::Clock::SharedPtr clock, int duration, Args... args)
+  void fatal_throttle(rclcpp::Clock::SharedPtr clock, int duration, const char* str,  Args... args)
   {
       RCLCPP_FATAL_THROTTLE(rclcpp_logger_, *clock, duration, write_buffer(str, args...) );
   }
@@ -97,7 +97,7 @@ public:
   }
 
   template<typename... Args>
-  void debug_throttle(const char* str, rclcpp::Clock::SharedPtr clock, int duration, Args... args)
+  void debug_throttle(rclcpp::Clock::SharedPtr clock, int duration, const char* str,  Args... args)
   {
       RCLCPP_DEBUG_THROTTLE(rclcpp_logger_, *clock, duration, write_buffer(str, args...) );
   }

--- a/include/ros2_logging_fmt/ros2_logging_fmt.hpp
+++ b/include/ros2_logging_fmt/ros2_logging_fmt.hpp
@@ -1,6 +1,8 @@
 #ifndef ROS2_LOGGING_PLUS_HPP
 #define ROS2_LOGGING_PLUS_HPP
 
+#include <chrono>
+
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
 
@@ -32,15 +34,15 @@ public:
   }
 
   template<typename... Args>
-  void info_throttle(rclcpp::Clock& clock, int duration, const char* str,  Args... args)
+  void info_throttle(rclcpp::Clock& clock, std::chrono::milliseconds duration, const char* str,  Args... args)
   {
-      RCLCPP_INFO_THROTTLE(rclcpp_logger_, clock, duration, write_buffer(str, args...) );
+    RCLCPP_INFO_THROTTLE(rclcpp_logger_, clock, duration.count(), write_buffer(str, args...) );
   }
 
   template<typename... Args>
-  void info_throttle(int duration, const char* str, Args... args)
+  void info_throttle(std::chrono::milliseconds duration, const char* str, Args... args)
   {
-      RCLCPP_INFO_THROTTLE(rclcpp_logger_, *clk, duration, write_buffer(str, args...) );
+    RCLCPP_INFO_THROTTLE(rclcpp_logger_, *clk, duration.count(), write_buffer(str, args...) );
   }
 
   template<typename... Args>
@@ -50,15 +52,15 @@ public:
   }
 
   template<typename... Args>
-  void warn_throttle(rclcpp::Clock &clock, int duration, const char* str,  Args... args)
+  void warn_throttle(rclcpp::Clock &clock, std::chrono::milliseconds duration, const char* str,  Args... args)
   {
-      RCLCPP_WARN_THROTTLE(rclcpp_logger_, clock, duration, write_buffer(str, args...) );
+    RCLCPP_WARN_THROTTLE(rclcpp_logger_, clock, duration.count(), write_buffer(str, args...) );
   }
 
   template<typename... Args>
-  void warn_throttle(int duration, const char* str, Args... args)
+  void warn_throttle(std::chrono::milliseconds duration, const char* str, Args... args)
   {
-      RCLCPP_WARN_THROTTLE(rclcpp_logger_, *clk, duration, write_buffer(str, args...) );
+    RCLCPP_WARN_THROTTLE(rclcpp_logger_, *clk, duration.count(), write_buffer(str, args...) );
   }
 
   template<typename... Args>
@@ -68,15 +70,15 @@ public:
   }
 
   template<typename... Args>
-  void error_throttle(rclcpp::Clock& clock, int duration, const char* str,  Args... args)
+  void error_throttle(rclcpp::Clock& clock, std::chrono::milliseconds duration, const char* str,  Args... args)
   {
-      RCLCPP_ERROR_THROTTLE(rclcpp_logger_, clock, duration, write_buffer(str, args...) );
+    RCLCPP_ERROR_THROTTLE(rclcpp_logger_, clock, duration.count(), write_buffer(str, args...) );
   }
 
   template<typename... Args>
-  void error_throttle(int duration, const char* str, Args... args)
+  void error_throttle(std::chrono::milliseconds duration, const char* str, Args... args)
   {
-      RCLCPP_ERROR_THROTTLE(rclcpp_logger_, *clk, duration, write_buffer(str, args...) );
+    RCLCPP_ERROR_THROTTLE(rclcpp_logger_, *clk, duration.count(), write_buffer(str, args...) );
   }
 
   template<typename... Args>
@@ -86,15 +88,15 @@ public:
   }
 
   template<typename... Args>
-  void fatal_throttle(rclcpp::Clock& clock, int duration, const char* str,  Args... args)
+  void fatal_throttle(rclcpp::Clock& clock, std::chrono::milliseconds duration, const char* str,  Args... args)
   {
-      RCLCPP_FATAL_THROTTLE(rclcpp_logger_, clock, duration, write_buffer(str, args...) );
+    RCLCPP_FATAL_THROTTLE(rclcpp_logger_, clock, duration.count(), write_buffer(str, args...) );
   }
 
   template<typename... Args>
-  void fatal_throttle(int duration, const char* str, Args... args)
+  void fatal_throttle(std::chrono::milliseconds duration, const char* str, Args... args)
   {
-      RCLCPP_FATAL_THROTTLE(rclcpp_logger_, *clk, duration, write_buffer(str, args...) );
+    RCLCPP_FATAL_THROTTLE(rclcpp_logger_, *clk, duration.count(), write_buffer(str, args...) );
   }
 
   template<typename... Args>
@@ -104,15 +106,15 @@ public:
   }
 
   template<typename... Args>
-  void debug_throttle(rclcpp::Clock& clock, int duration, const char* str,  Args... args)
+  void debug_throttle(rclcpp::Clock& clock, std::chrono::milliseconds duration, const char* str,  Args... args)
   {
-      RCLCPP_DEBUG_THROTTLE(rclcpp_logger_, clock, duration, write_buffer(str, args...) );
+    RCLCPP_DEBUG_THROTTLE(rclcpp_logger_, clock, duration.count(), write_buffer(str, args...) );
   }
 
   template<typename... Args>
-  void debug_throttle(int duration, const char* str, Args... args)
+  void debug_throttle(std::chrono::milliseconds duration, const char* str, Args... args)
   {
-      RCLCPP_DEBUG_THROTTLE(rclcpp_logger_, *clk, duration, write_buffer(str, args...) );
+    RCLCPP_DEBUG_THROTTLE(rclcpp_logger_, *clk, duration.count(), write_buffer(str, args...) );
   }
 
   rclcpp::Logger rclcpp_logger_;

--- a/src/test_logging.cpp
+++ b/src/test_logging.cpp
@@ -31,6 +31,16 @@ int main(int argc, char * argv[])
   logger_clk.warn_throttle(1000, "Warning: {} > {}", 30.1, 30.0);
   logger_clk.debug_throttle(500, "DEBUG MESSAGE");
 
+  ros2_logging_fmt::Logger logger_node(node);
+  logger_node.info("Hi there!");
+  logger_node.info_throttle(1000, "Hi there!");
+
+  rclcpp_lifecycle::LifecycleNode lf_node("test_lifecycle_node");
+  ros2_logging_fmt::Logger logger_lf_node(lf_node);
+  logger_lf_node.info("Hi there!");
+  logger_lf_node.info_throttle(1000, "Hi there!");
+
+
   rclcpp::shutdown();
   return 0;
 }

--- a/src/test_logging.cpp
+++ b/src/test_logging.cpp
@@ -19,6 +19,11 @@ int main(int argc, char * argv[])
   logger.warn("Warning: {} > {}", 30.1, 30.0);
   logger.debug("DEBUG MESSAGE");
 
+  logger.info_throttle(*node.get_clock(), 1000, "Hello {} number {}", world, 42);
+  logger.error_throttle(*node.get_clock(), 1000, "We have {} errors", 99);
+  logger.warn_throttle(*node.get_clock(),1000, "Warning: {} > {}", 30.1, 30.0);
+  logger.debug_throttle(*node.get_clock(),1000, "DEBUG MESSAGE");
+
   ros2_logging_fmt::Logger logger_clk(node.get_logger(), node.get_clock());
 
   logger_clk.info_throttle(1000, "Hello {} number {}", world, 42);

--- a/src/test_logging.cpp
+++ b/src/test_logging.cpp
@@ -14,34 +14,36 @@ int main(int argc, char * argv[])
   RCLCPP_WARN(node.get_logger(), "Warning: %f > %f", 30.1, 30.0);
   RCLCPP_DEBUG(node.get_logger(), "DEBUG MESSAGE");
 
+
   ros2_logging_fmt::Logger logger(node.get_logger());
 
   logger.info("Hello {} number {}", world, 42);
   logger.error("We have {} errors", 99);
   logger.warn("Warning: {} > {}", 30.1, 30.0);
   logger.debug("DEBUG MESSAGE");
-
   logger.info_throttle(*node.get_clock(), 1000ms, "Hello {} number {}", world, 42);
   logger.error_throttle(*node.get_clock(), 1000ms, "We have {} errors", 99);
   logger.warn_throttle(*node.get_clock(), 1000ms, "Warning: {} > {}", 30.1, 30.0);
   logger.debug_throttle(*node.get_clock(),1000ms, "DEBUG MESSAGE");
 
+
   ros2_logging_fmt::Logger logger_clk(node.get_logger(), node.get_clock());
 
-  logger_clk.info_throttle(1hr, "Hello {} number {}", world, 42);
+  logger_clk.info_throttle(1h, "Hello {} number {}", world, 42);
   logger_clk.error_throttle(1000ms, "We have {} errors", 99);
   logger_clk.warn_throttle(10s, "Warning: {} > {}", 30.1, 30.0);
   logger_clk.debug_throttle(5ms, "DEBUG MESSAGE");
 
+
   ros2_logging_fmt::Logger logger_node(node);
   logger_node.info("Hi there!");
-  logger_node.info_throttle(1000ms, "Hi there!");
+  logger_node.info_throttle(std::chrono::seconds{1}, "Hi there!");
+
 
   rclcpp_lifecycle::LifecycleNode lf_node("test_lifecycle_node");
   ros2_logging_fmt::Logger logger_lf_node(lf_node);
   logger_lf_node.info("Hi there!");
   logger_lf_node.info_throttle(1000ms, "Hi there!");
-
 
   rclcpp::shutdown();
   return 0;

--- a/src/test_logging.cpp
+++ b/src/test_logging.cpp
@@ -1,5 +1,7 @@
 #include "ros2_logging_fmt/ros2_logging_fmt.hpp"
 
+using namespace std::chrono_literals;
+
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
@@ -19,26 +21,26 @@ int main(int argc, char * argv[])
   logger.warn("Warning: {} > {}", 30.1, 30.0);
   logger.debug("DEBUG MESSAGE");
 
-  logger.info_throttle(*node.get_clock(), 1000, "Hello {} number {}", world, 42);
-  logger.error_throttle(*node.get_clock(), 1000, "We have {} errors", 99);
-  logger.warn_throttle(*node.get_clock(),1000, "Warning: {} > {}", 30.1, 30.0);
-  logger.debug_throttle(*node.get_clock(),1000, "DEBUG MESSAGE");
+  logger.info_throttle(*node.get_clock(), 1000ms, "Hello {} number {}", world, 42);
+  logger.error_throttle(*node.get_clock(), 1000ms, "We have {} errors", 99);
+  logger.warn_throttle(*node.get_clock(), 1000ms, "Warning: {} > {}", 30.1, 30.0);
+  logger.debug_throttle(*node.get_clock(),1000ms, "DEBUG MESSAGE");
 
   ros2_logging_fmt::Logger logger_clk(node.get_logger(), node.get_clock());
 
-  logger_clk.info_throttle(1000, "Hello {} number {}", world, 42);
-  logger_clk.error_throttle(1000, "We have {} errors", 99);
-  logger_clk.warn_throttle(1000, "Warning: {} > {}", 30.1, 30.0);
-  logger_clk.debug_throttle(500, "DEBUG MESSAGE");
+  logger_clk.info_throttle(1hr, "Hello {} number {}", world, 42);
+  logger_clk.error_throttle(1000ms, "We have {} errors", 99);
+  logger_clk.warn_throttle(10s, "Warning: {} > {}", 30.1, 30.0);
+  logger_clk.debug_throttle(5ms, "DEBUG MESSAGE");
 
   ros2_logging_fmt::Logger logger_node(node);
   logger_node.info("Hi there!");
-  logger_node.info_throttle(1000, "Hi there!");
+  logger_node.info_throttle(1000ms, "Hi there!");
 
   rclcpp_lifecycle::LifecycleNode lf_node("test_lifecycle_node");
   ros2_logging_fmt::Logger logger_lf_node(lf_node);
   logger_lf_node.info("Hi there!");
-  logger_lf_node.info_throttle(1000, "Hi there!");
+  logger_lf_node.info_throttle(1000ms, "Hi there!");
 
 
   rclcpp::shutdown();

--- a/src/test_logging.cpp
+++ b/src/test_logging.cpp
@@ -19,6 +19,13 @@ int main(int argc, char * argv[])
   logger.warn("Warning: {} > {}", 30.1, 30.0);
   logger.debug("DEBUG MESSAGE");
 
+  ros2_logging_fmt::Logger logger_clk(node.get_logger(), node.get_clock());
+
+  logger_clk.info_throttle(1000, "Hello {} number {}", world, 42);
+  logger_clk.error_throttle(1000, "We have {} errors", 99);
+  logger_clk.warn_throttle(1000, "Warning: {} > {}", 30.1, 30.0);
+  logger_clk.debug_throttle(500, "DEBUG MESSAGE");
+
   rclcpp::shutdown();
   return 0;
 }


### PR DESCRIPTION
This PR is to add throttle versions of the logging levels.

The implementation supports two methods. The first is just calling the throttle logging level and passing in a clock, or when creating a `Logger` object passing in a clock as well that is used internally. This is more in line with the usage in ROS1.

One difference is the duration is in ms per the RCLCPP library vs seconds as in ROS1.

Related issue https://github.com/facontidavide/ros2_logging_fmt/issues/1